### PR TITLE
Add Docker related information for Qualiexplore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+e2e
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Step 1: Build QualiExplore app in image 'builder'
+
+FROM node:12.8-alpine AS builder
+
+LABEL maintainer="Shantanoo Desai <shantanoo.desai@gmail.com, des@biba.uni-bremen.de>"
+
+WORKDIR /usr/src/app
+COPY . .
+RUN npm install && npm run build
+
+# Step 2: Use the build output from 'builder' image
+FROM nginx:stable-alpine
+LABEL version="1.0"
+
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+
+WORKDIR /usr/share/nginx/html
+COPY --from=builder /usr/src/app/dist/qualiexplore/ .

--- a/README.md
+++ b/README.md
@@ -17,6 +17,59 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 * [Shantanoo Desai](mailto:des@biba.uni-bremen.de)
 * [Stefan Wellsandt](mailto:wel@biba.uni-bremen.de)
 
+## Docker
+
+QualiExplore is served through `nginx` HTTP Server. See `Dockerfile` for details.
+Qualiexplore is also available on [Docker Hub](https://hub.docker.com/repository/docker/shantanoodesai/qualiexplore)
+
+### Local Development
+
+__Build Image__:
+
+```bash
+  npm run build:docker
+```
+
+__Run Image__:
+
+```bash
+  npm run start:docker
+```
+
+__Local Development Using `docker-compose`__:
+
+```yml
+version: '3.1'
+
+services:
+  qualiexplore:
+    image: 'qualiexplore'
+    build: '.'
+    ports:
+      - 3000:80
+```
+
+### Deployment
+
+1. Within `docker-compose.yml` add:
+
+  ```yml
+  version: '3.1'
+
+  services:
+    qualiexplore:
+      image: 'shantanoodesai/qualiexplore'
+      ports:
+        - 3000:80
+  ```
+
+2. Run using `docker` command:
+  ```bash
+    docker run -p 3000:80 --rm shantanoodesai/qualiexplore
+  ```
+
+
+
 ## License
 
 __Apache2.0 License__

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name  localhost;
+
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        include /etc/nginx/mime.types;
+
+        gzip on;
+        gzip_min_length 1000;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location ~ \.html$ {
+          add_header Cache-Control "private, no-cache, no-store, must-revalidate";
+          add_header Expires "Sat, 01 Jan 2000 00:00:00 GMT";
+          add_header Pragma no-cache;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --prod",
+    "build:docker": "docker image build -t qualiexplore .",
+    "start:docker": "docker run -p 3000:80 --rm qualiexplore",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
- Serve __QualiExplore__ using `nginx` HTTP server
- Provide and Publish Docker Image for __QualiExplore__
- Update Docker related Information in `README.md`


closes #1 